### PR TITLE
Remove unnecessary run function

### DIFF
--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -63,7 +63,7 @@ const makeInitResults = (description) => {
   }
 }
 
-const run = (benchmark) => {
+const runBenchmark = (benchmark) => {
   const iterationsAmount = benchmark.iterations || 1
   const results = makeInitResults(benchmark.description)
   const iterationResults = results.iterations
@@ -71,10 +71,6 @@ const run = (benchmark) => {
     iterationResults.push( doIteration(benchmark) )
   })
   return results
-}
-
-const runBenchmark = (benchmark) => {
-  return run(benchmark)
 }
 
 module.exports = {makeArray, repeat, doTest, runBenchmark}


### PR DESCRIPTION
## Description

This PR removes a function that was just used as a proxy to another function with the same signature. :smile:

## Explanation

The function below just takes an argument and passes along to another function:

```javascript
const runBenchmark = (benchmark) => {
  return run(benchmark)
}
```

This could be rewritten as below, with the same effects:

```javascript
const runBenchmark = run
```

I decided to remove the old `runBenchmark` function, and just rename the `run` function to `runBenchmark` so the public API does not get broken.